### PR TITLE
ZIP-156: hide departments with no tags

### DIFF
--- a/components/unzipped/dashboard/LeftListPanel.js
+++ b/components/unzipped/dashboard/LeftListPanel.js
@@ -32,11 +32,12 @@ const Action = styled.div`
 `;
 
 const Panel = ({list, business, selectList, type}) => {
+    const isDepartment = type === 'department';
     return (
         <Container>
-            <TitleText paddingLeft clickable>{business}<Absolute top="20px"><Action>{type === 'department' ? '' : '+ New List'}</Action></Absolute></TitleText>
-            <Underline />   
-            {list.map(item => (
+            <TitleText paddingLeft clickable>{business}<Absolute top="20px"><Action>{isDepartment ? '' : '+ New List'}</Action></Absolute></TitleText>
+            <Underline />
+            {list.filter(item => isDepartment ? item.tags.length > 0 : true).map(item => (
                 <WhiteCard borderColor="transparent" height="30px" row noMargin clickable onClick={() => selectList(item)}>
                     {item.icon}
                     <DarkText clickable noMargin paddingLeft hover>{item.text}</DarkText>


### PR DESCRIPTION
https://dev.azure.com/ClearfitLLC/Unzipped/_boards/board/t/Unzipped%20Team/Issues/?workitem=156

when there are no tags, the department fails to load stories and crashes. Newer departments are creating tags so this is data corruption on older data